### PR TITLE
[OPP-1331] la til modia-domene

### DIFF
--- a/nais-fss.yaml
+++ b/nais-fss.yaml
@@ -12,6 +12,7 @@ spec:
     - https://frontendlogger.nais.adeo.no
     - https://app.adeo.no/frontendlogger
     - https://modapp.adeo.no/frontendlogger
+    - https://modia.adeo.no/frontendlogger
   port: 8080
   liveness:
     path: frontendlogger/internal/isAlive

--- a/nais-q-fss.yaml
+++ b/nais-q-fss.yaml
@@ -13,6 +13,7 @@ spec:
     - https://app-{{namespace}}.adeo.no/frontendlogger
     - https://app-{{namespace}}.dev.adeo.no/frontendlogger
     - https://modapp-{{namespace}}.adeo.no/frontendlogger
+    - https://modia-{{namespace}}.dev.adeo.no/frontendlogger
   port: 8080
   liveness:
     path: frontendlogger/internal/isAlive


### PR DESCRIPTION
modiapersonoversikt og andre modia-løsninger bytter over til
modia.adeo.no for å unngå trøbbel med idToken-cookies og
andre systemer som bruker samme innloggingsmekanismer