### PR TITLE
[KAIZEN-0] godta nav-consumer-id som header

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -2,19 +2,28 @@ import no.nav.ApplicationConfig;
 import no.nav.apiapp.ApiApp;
 import no.nav.sbl.util.EnvironmentUtils;
 
+import static no.nav.apiapp.rest.NavCorsFilter.CORS_ALLOWED_HEADERS;
 import static no.nav.apiapp.rest.NavCorsFilter.CORS_ALLOWED_ORIGINS;
 import static no.nav.sbl.util.EnvironmentUtils.getOptionalProperty;
 import static no.nav.sbl.util.EnvironmentUtils.setProperty;
 
 public class Main {
-
     public static void main(String... args) throws Exception {
         setupCors();
         ApiApp.runApp(ApplicationConfig.class, args);
     }
 
     private static void setupCors() {
+        setProperty(CORS_ALLOWED_HEADERS, ALLOWED_HEADERS, EnvironmentUtils.Type.PUBLIC);
         getOptionalProperty("CORS_ALLOWED_ORIGINS")
                 .ifPresent((value) -> setProperty(CORS_ALLOWED_ORIGINS, value, EnvironmentUtils.Type.PUBLIC));
     }
+
+    private static final String ALLOWED_HEADERS = String.join(",",
+            "Accept",
+            "Accept-language",
+            "Content-Language",
+            "Content-Type",
+            "Nav-Consumer-Id"
+    );
 }


### PR DESCRIPTION
npm-pakken sender med denne headeren men det skaper trøbbel ved cross-origin requests. Legger derfor til unntak for headeren
